### PR TITLE
6 server keep track of client usernames

### DIFF
--- a/src/client_code/client.c
+++ b/src/client_code/client.c
@@ -44,8 +44,11 @@ int main(int argc, char* argv[]) {
   struct sockaddr_in udpAddress;                                                    // Will leave empty because do not need to bind
   memset(&udpAddress, 0, sizeof(udpAddress));                                       // 0 out
   udpSocketDescriptor = setupUdpSocket(udpAddress, 0);                              // Setup udp socket without binding
-  char* connectionPacket = malloc(CONNECTION_PACKET_SIZE);                          // Allocate connection packet
-  buildConnectionPacket(connectionPacket, udpAddress);                              // Build connection packet with appropriate fields
+  char* connectionPacket = malloc(CONNECTION_PACKET_SIZE);                          // Allocate connection packet string
+
+  struct ConnectionPacketFields connectionPacketFields;
+  strcpy(connectionPacketFields.username, getenv("USER"));
+  buildConnectionPacket(connectionPacket, connectionPacketFields, debugFlag);                   // Build connection packet with appropriate fields
   sendUdpMessage(udpSocketDescriptor, serverAddress, connectionPacket, debugFlag);  // Send connection packet to the server
   free(connectionPacket);                                                           // Free connection packet
 

--- a/src/client_code/client.c
+++ b/src/client_code/client.c
@@ -22,6 +22,7 @@ uint8_t debugFlag = 0;  // Can add conditional statements with this flag to prin
 // Global variables (for signal handler)
 int udpSocketDescriptor;
 char* userInput;
+
 // Main
 int main(int argc, char* argv[]) {
   // Assign callback function for ctrl-c
@@ -40,15 +41,16 @@ int main(int argc, char* argv[]) {
   // Check command line arguments
   checkCommandLineArguments(argc, argv, &debugFlag);
  
-  // Setup UDP socket and store its info
+  // Setup UDP socket
   struct sockaddr_in udpAddress;                                                    // Will leave empty because do not need to bind
   memset(&udpAddress, 0, sizeof(udpAddress));                                       // 0 out
   udpSocketDescriptor = setupUdpSocket(udpAddress, 0);                              // Setup udp socket without binding
-  char* connectionPacket = malloc(CONNECTION_PACKET_SIZE);                          // Allocate connection packet string
 
-  struct ConnectionPacketFields connectionPacketFields;
-  strcpy(connectionPacketFields.username, getenv("USER"));
-  buildConnectionPacket(connectionPacket, connectionPacketFields, debugFlag);                   // Build connection packet with appropriate fields
+  // Put together a connection packet
+  char* connectionPacket = malloc(CONNECTION_PACKET_SIZE);                          // Allocate connection packet string
+  struct ConnectionPacketFields connectionPacketFields;                             // Struct to store the fields to send
+  strcpy(connectionPacketFields.username, getenv("USER"));                          // Set the username of using the USER environment variable
+  buildConnectionPacket(connectionPacket, connectionPacketFields, debugFlag);       // Build the entire connection packet
   sendUdpMessage(udpSocketDescriptor, serverAddress, connectionPacket, debugFlag);  // Send connection packet to the server
   free(connectionPacket);                                                           // Free connection packet
 

--- a/src/common/network_node.h
+++ b/src/common/network_node.h
@@ -15,6 +15,7 @@
 #define INITIAL_MESSAGE_SIZE 100                                        // Max size of the initial calibration message
 #define MAX_CONNECTED_CLIENTS 100                                       // Maximum number of clients that can be connected to the server
 #define USER_INPUT_BUFFER_LENGTH 40                                     // Max size of message a user can input
+#define USERNAME_SIZE 20
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/common/network_node.h
+++ b/src/common/network_node.h
@@ -15,7 +15,7 @@
 #define INITIAL_MESSAGE_SIZE 100                                        // Max size of the initial calibration message
 #define MAX_CONNECTED_CLIENTS 100                                       // Maximum number of clients that can be connected to the server
 #define USER_INPUT_BUFFER_LENGTH 40                                     // Max size of message a user can input
-#define USERNAME_SIZE 20
+#define USERNAME_SIZE 20                                                // Max size of a username
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/common/packet.c
+++ b/src/common/packet.c
@@ -7,15 +7,43 @@
 
 #include "packet.h"
 
-struct ConnectionPacket connectionPacket = {
-  "startconnect",
-  "$",
-  "endconnect"
+// Delimiters in a connection packet. The same in every connection packet
+struct ConnectionPacketDelimiters connectionPacketDelimiters = {
+  "startconnect", // beginning 
+  "$",            // middle
+  "endconnect"    // end
 };
 
-void buildConnectionPacket(char* builtPacket, struct sockaddr_in packetSource) {
-  strncat(builtPacket, connectionPacket.beginning, strlen(connectionPacket.beginning)); // Add beginning field to packet
-  char username[20] = "username";                                                       // Hard coded username for now
-  strncat(builtPacket, connectionPacket.end, strlen(connectionPacket.end));             // Add end field to packet
+/*
+  * Name: buildConnectionPacket
+  * Purpose: Construct a connection packet
+  * Input: 
+  * - String where the packet is
+  * - Address structure of the source of the packet
+  * - Debug flag
+  * Output: None
+*/
+void buildConnectionPacket(char* builtPacket, struct ConnectionPacketFields connectionPacketFields, uint8_t debugFlag) {
+  strncat(builtPacket, connectionPacketDelimiters.beginning, strlen(connectionPacketDelimiters.beginning)); // Add beginning delimiter to packet
+  strncat(builtPacket, connectionPacketFields.username, strlen(connectionPacketFields.username));                                                         // Add username field to packet
+  strncat(builtPacket, connectionPacketDelimiters.end, strlen(connectionPacketDelimiters.end));             // Add end delimiter to packet
+  if (debugFlag) {                                                                                          // If debug flag
+    printf("Connection packet: %s\n", builtPacket);                                                         // Print out the whole packet
+  }
+}
 
+int readConnectionPacket(char* packetToBeRead, struct ConnectionPacketFields* readPacketFields) {
+  // Delimiters
+  char* beginning = connectionPacketDelimiters.beginning;
+  char* middle = connectionPacketDelimiters.middle;
+  char* end = connectionPacketDelimiters.end;
+
+  // Check if beginning of the packet is correct
+  if (strncmp(packetToBeRead, beginning, strlen(beginning)) != 0) {
+    return -1;
+  }
+  packetToBeRead += strlen(beginning);                                  // Advance past the beginning
+  int usernameLength = strlen(packetToBeRead) - strlen(end);            // packet is now just username and end
+  strncpy(readPacketFields->username, packetToBeRead, usernameLength);  // Read the username into the returned type
+  return 0;
 }

--- a/src/common/packet.c
+++ b/src/common/packet.c
@@ -32,6 +32,14 @@ void buildConnectionPacket(char* builtPacket, struct ConnectionPacketFields conn
   }
 }
 
+/*
+  * Name: readConnectionPacket
+  * Purpose: Read a connection packet that has been sent
+  * Input:
+  * - String containing the packet that was sent
+  * - The fields read from the packet
+  * Output: Whether or not the packet is valid
+*/
 int readConnectionPacket(char* packetToBeRead, struct ConnectionPacketFields* readPacketFields) {
   // Delimiters
   char* beginning = connectionPacketDelimiters.beginning;

--- a/src/common/packet.h
+++ b/src/common/packet.h
@@ -7,12 +7,21 @@
 #include <sys/types.h>
 #include <netdb.h>
 
-struct ConnectionPacket {
-  char beginning[20];
-  char delimiter[20];
-  char end[20];
+#include "network_node.h"
+
+// Delimiters in a connection packet. The same in every connection packet
+struct ConnectionPacketDelimiters {
+  char beginning[20]; // Beginning of the packet
+  char middle[20];    // Seperate the fields of the packet
+  char end[20];       // End of the packet
 };
 
-void buildConnectionPacket(char*, struct sockaddr_in);
+// Fields in a connection packet that will have variable information 
+struct ConnectionPacketFields {
+  char username[USERNAME_SIZE];
+};
+
+void buildConnectionPacket(char*, struct ConnectionPacketFields, uint8_t);
+int readConnectionPacket(char*, struct ConnectionPacketFields*);
 
 #endif

--- a/src/common/packet.h
+++ b/src/common/packet.h
@@ -16,12 +16,12 @@ struct ConnectionPacketDelimiters {
   char end[20];       // End of the packet
 };
 
-// Fields in a connection packet that will have variable information 
+// Fields in a connection packet that will be set by the sender and read by the receiver
 struct ConnectionPacketFields {
   char username[USERNAME_SIZE];
 };
 
-void buildConnectionPacket(char*, struct ConnectionPacketFields, uint8_t);
-int readConnectionPacket(char*, struct ConnectionPacketFields*);
+void buildConnectionPacket(char*, struct ConnectionPacketFields, uint8_t);  // Build a connection packet with the delimiters and the fields
+int readConnectionPacket(char*, struct ConnectionPacketFields*);            // Get the fields out of a connection packet
 
 #endif

--- a/src/server_code/server.c
+++ b/src/server_code/server.c
@@ -47,9 +47,9 @@ int main(int argc, char* argv[]) {
   
   checkCommandLineArguments(argc, argv, &debugFlag);  // Check if user passed any arguments
 
-  listeningUDPSocketDescriptor = setupUdpSocket(serverAddress, 1);                      // Setup the UDP socket
+  listeningUDPSocketDescriptor = setupUdpSocket(serverAddress, 1);  // Setup the UDP socket
   
-  message = malloc(INITIAL_MESSAGE_SIZE);       // Space for incoming messages
+  message = malloc(INITIAL_MESSAGE_SIZE);             // Space for incoming messages
   
   // Whether or not data is available at the socket. If it is, what kind.
   int udpStatus;
@@ -63,6 +63,7 @@ int main(int argc, char* argv[]) {
       break;
 
       case 1:                                         // Something
+      // Read connection packet
       struct ConnectionPacketFields connectionPacketFields;
       uint8_t validPacket = readConnectionPacket(message, &connectionPacketFields);
       if (validPacket == -1) {
@@ -70,10 +71,11 @@ int main(int argc, char* argv[]) {
         continue;
       }
 
-      int emptyConnectedClientIndex = findEmptyConnectedClient(debugFlag);
-      strcpy(connectedClients[emptyConnectedClientIndex].username, connectionPacketFields.username);
-      connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_addr.s_addr = clientUDPAddress.sin_addr.s_addr;
-      connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_port = clientUDPAddress.sin_port;
+      // Find an empty connection client and fill it out with the info from the connection packet
+      int emptyConnectedClientIndex = findEmptyConnectedClient(debugFlag);                                              // Find an empty connected client
+      strcpy(connectedClients[emptyConnectedClientIndex].username, connectionPacketFields.username);                    // username
+      connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_addr.s_addr = clientUDPAddress.sin_addr.s_addr;  // UDP address
+      connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_port = clientUDPAddress.sin_port;                // UDP port
       printAllConnectedClients();
       break;
 
@@ -135,16 +137,16 @@ void printAllConnectedClients() {
   unsigned long udpAddress;
   unsigned short udpPort;
   for (i = 0; i < MAX_CONNECTED_CLIENTS; i++) {
-    udpAddress = ntohl(connectedClients[i].socketUdpAddress.sin_addr.s_addr);
-    udpPort = ntohs(connectedClients[i].socketUdpAddress.sin_port);
-    if (udpAddress == 0 && udpPort == 0) {
+    udpAddress = ntohl(connectedClients[i].socketUdpAddress.sin_addr.s_addr); // UDP address
+    udpPort = ntohs(connectedClients[i].socketUdpAddress.sin_port);           // UDP port
+    if (udpAddress == 0 && udpPort == 0) {                                    // Check if the client is empty
       continue;
     }
-    char username[USERNAME_SIZE];
+    char username[USERNAME_SIZE];                                             // Username
     strcpy(username, connectedClients[i].username);
     printf("CONNECTED CLIENT %d\n", i);
-    printf("USERNAME: %s\n", username);
-    printf("UDP ADDRESS: %ld\n", udpAddress);
-    printf("UDP PORT: %d\n", udpPort);
+    printf("USERNAME: %s\n", username);                                       // Print username
+    printf("UDP ADDRESS: %ld\n", udpAddress);                                 // Print UDP address
+    printf("UDP PORT: %d\n", udpPort);                                        // Print UDP port
   }
 }

--- a/src/server_code/server.c
+++ b/src/server_code/server.c
@@ -63,7 +63,15 @@ int main(int argc, char* argv[]) {
       break;
 
       case 1:                                         // Something
+      struct ConnectionPacketFields connectionPacketFields;
+      uint8_t validPacket = readConnectionPacket(message, &connectionPacketFields);
+      if (validPacket == -1) {
+        printf("Invalid connection packet received\n");
+        continue;
+      }
+
       int emptyConnectedClientIndex = findEmptyConnectedClient(debugFlag);
+      strcpy(connectedClients[emptyConnectedClientIndex].username, connectionPacketFields.username);
       connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_addr.s_addr = clientUDPAddress.sin_addr.s_addr;
       connectedClients[emptyConnectedClientIndex].socketUdpAddress.sin_port = clientUDPAddress.sin_port;
       printAllConnectedClients();
@@ -132,7 +140,10 @@ void printAllConnectedClients() {
     if (udpAddress == 0 && udpPort == 0) {
       continue;
     }
+    char username[USERNAME_SIZE];
+    strcpy(username, connectedClients[i].username);
     printf("CONNECTED CLIENT %d\n", i);
+    printf("USERNAME: %s\n", username);
     printf("UDP ADDRESS: %ld\n", udpAddress);
     printf("UDP PORT: %d\n", udpPort);
   }

--- a/src/server_code/server.h
+++ b/src/server_code/server.h
@@ -3,6 +3,7 @@
 
 // Data about a client connected to the server
 struct connectedClient {
+  char username[USERNAME_SIZE];
   struct sockaddr_in socketUdpAddress;                    // Address structure of connected client's UDP socket
 };
 


### PR DESCRIPTION
- Added a USERNAME_SIZE constant to network node.
- Changed ConnectionPacket to ConnectionPacketDelimiters.
- Added a new type, ConnectionPacketFields. Contains info in a connection packet that the sender sets before it sends the packet.
- Added username field to ConnectedClient type.
- Added a function, buildConnectionPacket() to put together a connection packet with its delimiters and fields.
- Added a function, readConnectionPacket() to read the fields from a connection packet.
- Server now reads in a connection packet if it receives a message on its UDP port. It then sets an empty connected client based on the fields read from the connection packet.
- printAllConnectedClients() now prints the username field.